### PR TITLE
Fix: Prevent crash from mock recap URIs

### DIFF
--- a/utils/recap.ts
+++ b/utils/recap.ts
@@ -8,7 +8,10 @@ export class RecapGenerator {
       // Por ahora, crearemos un placeholder
       const mockRecapUri = 'mock://weekly-recap';
       
-      return await VideoStorage.saveRecap(mockRecapUri, 'weekly', year, weekNumber);
+      // return await VideoStorage.saveRecap(mockRecapUri, 'weekly', year, weekNumber);
+      // TODO: Implement actual video merging for weekly recaps
+      console.warn(`Skipping weekly recap generation for week ${weekNumber}, year ${year}: Video merging not implemented.`);
+      return null;
     } catch (error) {
       console.error('Error generating weekly recap:', error);
       return null;
@@ -21,7 +24,10 @@ export class RecapGenerator {
       // Por ahora, crearemos un placeholder
       const mockRecapUri = 'mock://monthly-recap';
       
-      return await VideoStorage.saveRecap(mockRecapUri, 'monthly', year, month);
+      // return await VideoStorage.saveRecap(mockRecapUri, 'monthly', year, month);
+      // TODO: Implement actual video merging for monthly recaps
+      console.warn(`Skipping monthly recap generation for month ${month}, year ${year}: Video merging not implemented.`);
+      return null;
     } catch (error) {
       console.error('Error generating monthly recap:', error);
       return null;


### PR DESCRIPTION
This commit addresses a bug where the application would crash when trying to save weekly or monthly recaps due to the use of 'mock://' URIs, which are not valid file paths for `FileSystem.moveAsync`.

The `generateWeeklyRecap` and `generateMonthlyRecap` functions in `utils/recap.ts` were using these placeholder URIs.

The fix involves commenting out the calls to `VideoStorage.saveRecap` in these functions and adding `console.warn` messages to indicate that recap generation is skipped because the video merging functionality is not yet implemented.

This prevents the crash and defers actual recap generation until the necessary video processing logic is in place.